### PR TITLE
Mod: Modify cutscene and fix flag names

### DIFF
--- a/archipelago_companion/managers/ArchipelagoConnectionManager.gd
+++ b/archipelago_companion/managers/ArchipelagoConnectionManager.gd
@@ -163,7 +163,7 @@ func _onAbilityReceived(abilityName: String):
 	print("Ability %s given to player" % abilityName)
 
 func _onSongReceived(aaName: String):
-	SaveState.set_flag("ap_encounter_" + aaName, true)
+	SaveState.set_flag("ap_song_part_" + aaName, true)
 	print("Song for archangel %s given to player" % aaName)
 
 func _onStampReceived(stampFlag: String):
@@ -171,9 +171,9 @@ func _onStampReceived(stampFlag: String):
 	print("Stamp for captain %s given to player" % stampFlag)
 
 func _onFlagChanged(flag: String, value: bool):
-	if "captain" in flag and value:
+	if "encounter_captain" in flag and value:
 		return sendCaptainDefeated(flag)
-	if "aa" in flag and !("encounter" in flag) and value:
+	if "encounter_aa" in flag and value:
 		return sendArchAngelDefeated(flag)
 
 # sending checks to server
@@ -186,9 +186,10 @@ func sendChestOpened(chestFlag: String):
 	_sendCheckLocation(chestFlag)
 
 func sendArchAngelDefeated(aaFlag: String):
-	print("Archangel defeated: %s" % aaFlag)
+	var locationString = "ap_" + aaFlag
+	print("Archangel defeated: %s" % locationString)
 	# there may be some additional information added
-	_sendCheckLocation(aaFlag)
+	_sendCheckLocation(locationString)
 
 func sendAbilityUnlocked(abilityName: String):
 	print("Ability Unlocked: %s" % abilityName)

--- a/archipelago_companion/mod.gd
+++ b/archipelago_companion/mod.gd
@@ -33,9 +33,11 @@ func init_content() -> void:
 	var apShowStampCardAction = preload("extensions/ShowStampCardActionAP.gd")
 	apShowStampCardAction.take_over_path("res://nodes/actions/ShowStampCardAction.gd")
 	# connect to any scenes that we need modified
-	DLC.mods_by_id.cat_modutils.callbacks.connect_scene_ready("res://menus/settings/SettingsMenu.tscn", self, "_onSettingsMenuReady")
-	DLC.mods_by_id.cat_modutils.callbacks.connect_scene_ready("res://cutscenes/intro/OutskirtsWrongWay.tscn", self, "_onOutskirtsWrongWay")
-	DLC.mods_by_id.cat_modutils.callbacks.connect_class_ready("res://world/core/ConditionalLayer.gd", self, "_removeInvisWalls")
+	var callbacks = DLC.mods_by_id.cat_modutils.callbacks
+	callbacks.connect_scene_ready("res://menus/settings/SettingsMenu.tscn", self, "_onSettingsMenuReady")
+	callbacks.connect_scene_ready("res://cutscenes/intro/OutskirtsWrongWay.tscn", self, "_onOutskirtsWrongWay")
+	callbacks.connect_class_ready("res://world/core/ConditionalLayer.gd", self, "_removeInvisWalls")
+	callbacks.connect_scene_ready("res://cutscenes/intro/PensbyIntro.tscn", self, "_giveKayleighEarly")
 
 # adds the AP Settings page to the menu
 func _onSettingsMenuReady(scene: Control):
@@ -56,3 +58,22 @@ func _onOutskirtsWrongWay(scene: CheckConditionAction):
 func _removeInvisWalls(scene: Node):
 	if scene.name == "ConditionalLayer_Tutorial":
 		scene.queue_free()
+
+func _giveKayleighEarly(scene: Cutscene):
+	scene.get_node("QuestStartAction").queue_free()
+	var unlockKayleighAction = UnlockPartnerAction.new()
+	unlockKayleighAction.partner_id = "kayleigh"
+	scene.add_child(unlockKayleighAction)
+	# need to use resource loading in order to grab the correct taken over class
+	var giveHarbourtownKeyAction = load("res://nodes/actions/GiveItemAction.gd").new()
+	giveHarbourtownKeyAction.item = ItemFactory.generate_item(load("res://data/items/key_harbourtown.tres"))
+	scene.add_child(giveHarbourtownKeyAction)
+	var setEncounterAction = CheckConditionAction.new()
+	setEncounterAction.set_flags = ["encounter_aa_oldgante"]
+	scene.add_child(setEncounterAction)
+	scene.add_child(WaitAction.new())
+	var warpToCafeAction = WarpAction.new()
+	warpToCafeAction.warp_target_scene = "res://world/maps/interiors/GramophoneInterior.tscn"
+	warpToCafeAction.warp_target_name = "CafeTable"
+	scene.add_child(warpToCafeAction)
+

--- a/archipelago_companion/patched_classes/ArchangelQuestAP.gd
+++ b/archipelago_companion/patched_classes/ArchangelQuestAP.gd
@@ -65,7 +65,7 @@ func update_clue_count():
 	for id in archangel_ids:
 		var flag = "encounter_" + id
 		# PATCH: ADD LINES HERE
-		flag = "ap_" + flag
+		flag = "ap_song_part_" + id
 		# PATCH: STOP
 		if SaveState.has_flag(flag):
 			archangels_defeated += 1

--- a/archipelago_companion/patched_classes/StampSlotAP.gd
+++ b/archipelago_companion/patched_classes/StampSlotAP.gd
@@ -39,7 +39,7 @@ func is_met()->bool:
 func is_defeated()->bool:
 	var flag_name = "encounter_" + captain_id
 	# PATCH: ADD LINES HERE
-	flag_name = "AP_" + captain_id + "_stamp"
+	flag_name = "ap_" + captain_id + "_stamp"
 	# PATCH: STOP
 	return captain_id != "" and SaveState.has_flag(flag_name)
 


### PR DESCRIPTION
Modifies the Pensby Intro cutscene to get Kayleigh, get the harbourtown gate key (which becomes a check), set oldgante flag, and warp to the cafe.
Fixes the send and receive song code to no longer collide logically.
Fixes the stamp item flag name to be lowercase ap.