### PR TITLE
AP: Fix chest 0,-2 access logic.

### DIFF
--- a/cassette_beasts/Locations.py
+++ b/cassette_beasts/Locations.py
@@ -134,7 +134,7 @@ base_locations = {
 			lambda state, player: state.has("Progressive Dash", player)),
 	"Upper Path Magnet Platform Chest (0,-2)": 
 		CassetteBeastsLocationData("overworld_0_-2_chest", "Upper Path", next(c),
-			lambda state, player: state.has("Progressive Magnetism", player)),
+			lambda state, player: state.has("Progressive Magnetism", player) and state.has("Progressive Glide", player, 1)),
 	"Thirstaton Lake Underwater Chest (0,-3)": 
 		CassetteBeastsLocationData("overworld_0_-3_chest", "Thirstaton Lake", next(c),
 			lambda state, player: state.has("Progressive Dash", player)),

--- a/cassette_beasts_tracker/locations/locations.jsonc
+++ b/cassette_beasts_tracker/locations/locations.jsonc
@@ -385,7 +385,7 @@
           {
             "name": "Upper Path Magnet Platform Chest (0,-2)",
             "item_count": 1,
-            "access_rules": ["magnetism"],
+            "access_rules": ["glide,magnetism"],
             "visibility_rules": []
           },
           {


### PR DESCRIPTION
Fixes the logic to access the magnet chest in 0,-2 to include glide as well as magnetism.