### PR TITLE
AP,Tracker: Fix chest 6,-1 access logic.

### DIFF
--- a/cassette_beasts/Locations.py
+++ b/cassette_beasts/Locations.py
@@ -315,7 +315,8 @@ base_locations = {
 	"Averevoir Cave Chest (-3,-6)": 
 		CassetteBeastsLocationData("chest_cave_averevoir", "Mt Wirral", next(c)),
 	"Deadlands Cave Chest (6,-1)": 
-		CassetteBeastsLocationData("cave_deadlands_1_chest", "Deadlands Coast", next(c)),
+		CassetteBeastsLocationData("cave_deadlands_1_chest", "Deadlands Coast", next(c),
+            lambda state, player: state.has("Progressive Dash", player) or state.has("Progressive Climb", player)),
 	"Deadlands Cave Break Rock Chest (6,-2)": 
 		CassetteBeastsLocationData("cave_deadlands_3_chest", "Deadlands Coast", next(c),
 			lambda state, player: state.has("Progressive Dash", player)),

--- a/cassette_beasts_tracker/locations/locations.jsonc
+++ b/cassette_beasts_tracker/locations/locations.jsonc
@@ -2125,13 +2125,13 @@
           {
             "name": "Deadlands Cave Chest (6,-1)",
             "item_count": 1,
-            "access_rules": [],
+            "access_rules": ["climb", "dash"],
             "visibility_rules": []
           },
           {
             "name": "Deadlands Cave Chest Loot (6,-1)",
             "item_count": 1,
-            "access_rules": [],
+            "access_rules": ["climb", "dash"],
             "visibility_rules": [
               "setting_loot"
             ]


### PR DESCRIPTION
Adds climb or dash access logic to the 6,-1 cave chest.