### PR TITLE
Tracker: Fix cherry meadow box location.

### DIFF
--- a/cassette_beasts_tracker/locations/locations.jsonc
+++ b/cassette_beasts_tracker/locations/locations.jsonc
@@ -2961,7 +2961,7 @@
         "map_locations": [
           {
             "map": "new_wirral",
-            "x": 176,
+            "x": 166,
             "y": 144
           }
         ]


### PR DESCRIPTION
Moves the cherry meadow tracker box out from under the Thirstaton lake box.
<img width="460" height="471" alt="image" src="https://github.com/user-attachments/assets/e36e45f7-473f-4fc8-9e83-d010d4e4847f" />
